### PR TITLE
feat: socket using system proxy config

### DIFF
--- a/PocketSocket/PSWebSocket.m
+++ b/PocketSocket/PSWebSocket.m
@@ -160,7 +160,7 @@
         if(port == 0) {
             port = (_secure) ? 443 : 80;
         }
-        
+
         CFReadStreamRef readStream = nil;
         CFWriteStreamRef writeStream = nil;
         CFStreamCreatePairWithSocketToHost(kCFAllocatorDefault,
@@ -168,6 +168,14 @@
                                            port,
                                            &readStream,
                                            &writeStream);
+
+        CFDictionaryRef systemProxyConfig = CFNetworkCopySystemProxySettings();
+        if(systemProxyConfig != nil) {
+            CFReadStreamSetProperty(readStream, kCFStreamPropertySOCKSProxy, systemProxyConfig);
+            CFWriteStreamSetProperty(writeStream, kCFStreamPropertySOCKSProxy, systemProxyConfig);
+            CFRelease(systemProxyConfig);
+        }
+
         NSAssert(readStream && writeStream, @"Failed to create streams for client socket");
 
         NSString *networkServiceType = nil;
@@ -191,10 +199,10 @@
         default:
             NSAssert(false, @"Unhandled networkServiceType %tu", request.networkServiceType);
         }
-        
+
         _inputStream = CFBridgingRelease(readStream);
         _outputStream = CFBridgingRelease(writeStream);
-        
+
         if (networkServiceType != nil) {
             [_inputStream setProperty:networkServiceType forKey:NSStreamNetworkServiceType];
             [_outputStream setProperty:networkServiceType forKey:NSStreamNetworkServiceType];
@@ -222,9 +230,9 @@
             [NSException raise:@"Invalid State" format:@"You cannot open a PSWebSocket more than once."];
             return;
         }
-        
+
         self->_opened = YES;
-        
+
         // connect
         [self connect];
     }];
@@ -236,7 +244,7 @@
             [NSException raise:@"Invalid State" format:@"You cannot send a PSWebSocket messages before it is finished opening."];
             return;
         }
-        
+
         if([message isKindOfClass:[NSString class]]) {
             [self->_driver sendText:message];
         } else if([message isKindOfClass:[NSData class]]) {
@@ -272,25 +280,25 @@
     if(_readyState >= PSWebSocketReadyStateClosing) {
         return;
     }
-    
+
     BOOL connecting = (_readyState == PSWebSocketReadyStateConnecting);
     _readyState = PSWebSocketReadyStateClosing;
-    
+
     // send close code if we're not connecting
     if(!connecting) {
         _closeCode = code;
         [_driver sendCloseCode:code reason:reason];
     }
-    
+
     // disconnect gracefully
     [self disconnectGracefully];
-    
+
     // disconnect hard in 30 seconds
     __weak typeof(self)weakSelf = self;
     dispatch_after(dispatch_walltime(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf)strongSelf = weakSelf;
         if(!strongSelf) return;
-        
+
         [strongSelf executeWork:^{
             if(strongSelf->_readyState >= PSWebSocketReadyStateClosed) {
                 return;
@@ -323,17 +331,17 @@
 
 - (void)connect {
     if(_secure && _mode == PSWebSocketModeClient) {
-        
+
         __block BOOL customTrustEvaluation = NO;
         [self executeDelegateAndWait:^{
             customTrustEvaluation = [self->_delegate respondsToSelector:@selector(webSocket:evaluateServerTrust:)];
         }];
-        
+
         NSMutableDictionary *ssl = [NSMutableDictionary dictionary];
         ssl[(__bridge id)kCFStreamSSLLevel] = (__bridge id)kCFStreamSocketSecurityLevelNegotiatedSSL;
         ssl[(__bridge id)kCFStreamSSLValidatesCertificateChain] = @(!customTrustEvaluation);
         ssl[(__bridge id)kCFStreamSSLIsServer] = @NO;
-        
+
         _negotiatedSSL = !customTrustEvaluation;
         [_inputStream setProperty:ssl forKey:(__bridge id)kCFStreamPropertySSLSettings];
     }
@@ -341,10 +349,10 @@
     // delegate
     [_inputStream setWeakDelegate:self];
     [_outputStream setWeakDelegate:self];
-    
+
     // driver
     [_driver start];
-    
+
     // schedule streams
     CFReadStreamSetDispatchQueue((__bridge CFReadStreamRef)_inputStream, _workQueue);
     CFWriteStreamSetDispatchQueue((__bridge CFWriteStreamRef)_outputStream, _workQueue);
@@ -356,11 +364,11 @@
     if(_outputStream.streamStatus == NSStreamStatusNotOpen) {
         [_outputStream open];
     }
-    
+
     // pump
     [self pumpInput];
     [self pumpOutput];
-    
+
     // prepare timeout
     if(_request.timeoutInterval > 0.0) {
         __weak typeof(self)weakSelf = self;
@@ -383,10 +391,10 @@
 - (void)disconnect {
     [_inputStream setWeakDelegate:nil];
     [_outputStream setWeakDelegate:nil];
-    
+
     [_inputStream close];
     [_outputStream close];
-    
+
     _inputStream = nil;
     _outputStream = nil;
 }
@@ -397,7 +405,7 @@
     if (_negotiatedSSL) {
         return;
     }
-    
+
     SecTrustRef trust = (__bridge SecTrustRef)[stream propertyForKey:(__bridge id)kCFStreamPropertySSLPeerTrust];
     BOOL accept = [self askDelegateToEvaluateServerTrust:trust];
     if(accept) {
@@ -451,7 +459,7 @@
         }
 
         [_inputBuffer compact];
-        
+
         if(_readyState == PSWebSocketReadyStateOpen &&
            !_inputStream.hasBytesAvailable &&
            !_inputBuffer.hasBytesAvailable) {
@@ -466,7 +474,7 @@
        _outputPaused) {
         return;
     }
-    
+
     self.pumpingOutput = YES;
     do {
         while(_outputStream.hasSpaceAvailable && _outputBuffer.hasBytesAvailable) {
@@ -487,14 +495,14 @@
             _inputStream.streamStatus != NSStreamStatusClosed) &&
            !_sentClose) {
             _sentClose = YES;
-            
+
             [self disconnect];
-            
+
             if(!_failed) {
                 [self notifyDelegateDidCloseWithCode:_closeCode reason:_closeReason wasClean:YES];
             }
         }
-        
+
         [_outputBuffer compact];
 
         if(_readyState == PSWebSocketReadyStateOpen &&
@@ -502,7 +510,7 @@
            !_outputBuffer.hasBytesAvailable) {
             [self notifyDelegateDidFlushOutput];
         }
-        
+
     } while (_outputStream.hasSpaceAvailable && _outputBuffer.hasBytesAvailable);
     self.pumpingOutput = NO;
 }


### PR DESCRIPTION
Reads the system proxy settings and if that is non nil, sets the
socksproxy property of the ws socket. Notice that the system proxy
config could contain other proxy types, like HTTP proxies, but they
seem to be ignored.

The motivation for doing this is using a SOCKS proxy inside the docker
network exposed to the guest network. This allows the guest system to
use docker dns and private IPs without exposing local ports. This give
us more options to test the system, as we could use a remote docker
deployment.

Related to: https://github.com/sketch-hq/Cloud/issues/6520