### PR TITLE
Core Review:  Fix libgit2 submodules index (#39524)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pages"]
-	path = pages
-	url = git://github.com/zwopple/PocketSocket.git


### PR DESCRIPTION
Fixes https://github.com/sketch-hq/Sketch/issues/39524

The changes remove unused submodule config at `Modules/PocketSocket/.gitmodules`. The original `PocketSocket` doesn't have the file. Presumably, it's a leftover from the second fork. 

Sorry, I didn't figure out how to use `bo` to manage non-main-sketch repository tasks 🙇 